### PR TITLE
Allow Merge type commit messages in the pre-commit hook. Useful for syncing forks

### DIFF
--- a/scripts/verifyCommit.js
+++ b/scripts/verifyCommit.js
@@ -7,8 +7,9 @@ const msg = require('fs')
   .trim()
 
 const commitRE = /^(revert: )?(feat|fix|docs|dx|style|refactor|perf|test|workflow|build|ci|chore|types|wip|release)(\(.+\))?: .{1,50}/
+const mergeRE = /^Merge .+ branch '.+'/
 
-if (!commitRE.test(msg)) {
+if (!commitRE.test(msg) && !mergeRE.test(msg)) {
   console.log()
   console.error(
     `  ${chalk.bgRed.white(' ERROR ')} ${chalk.red(


### PR DESCRIPTION
To avoid this kind of errors which would happen to anyone wanting to contribute to the code by making a fork:

<img width="927" alt="Screenshot 2020-03-06 at 13 40 17" src="https://user-images.githubusercontent.com/136875/76085652-c3ae0300-5fb2-11ea-8449-abcd95e1dddd.png">

